### PR TITLE
Fix csv returning undefined

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ const objToArray = (row: {} | []): any[] =>
 const processRow = (row: {}, columns: ColumnModel[], ignoreType: boolean): string => {
     const finalVal = objToArray(row).reduce((prev: string, value: [], i: number) => {
         if (!columns[i].visible) {
-            return;
+            return prev;
         }
 
         let result = getCellValue(ignoreType ? ColumnDataType.String : columns[i].dataType, value).replace(/"/g, '""');

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,0 +1,33 @@
+import { ColumnDataType, createColumn, getCsv } from '../src';
+
+describe('getCsv', () => {
+    it('should not return undefined if a column is not visible', () => {
+        const columns = [
+            createColumn('test', {
+                label: 'test column',
+                visible: true,
+                dataType: ColumnDataType.String,
+            }),
+            createColumn('broken', {
+                label: 'broken column',
+                visible: false,
+                dataType: ColumnDataType.String,
+            }),
+        ];
+
+        const data = [
+            {
+                test: 'test value!',
+                broken: 'broken value!',
+            },
+            {
+                test: 'test value 2!',
+                broken: 'broken value 2!',
+            },
+        ] as any;
+
+        const output = getCsv(data, columns);
+
+        expect(output).toEqual('test column\ntest value!\ntest value 2!\n');
+    });
+});

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -3,13 +3,18 @@ import { ColumnDataType, createColumn, getCsv } from '../src';
 describe('getCsv', () => {
     it('should not return undefined if a column is not visible', () => {
         const columns = [
-            createColumn('test', {
-                label: 'test column',
+            createColumn('first', {
+                label: 'first column',
                 visible: true,
                 dataType: ColumnDataType.String,
             }),
-            createColumn('broken', {
-                label: 'broken column',
+            createColumn('second', {
+                label: 'second column',
+                visible: true,
+                dataType: ColumnDataType.String,
+            }),
+            createColumn('hidden', {
+                label: 'hidden column',
                 visible: false,
                 dataType: ColumnDataType.String,
             }),
@@ -17,17 +22,26 @@ describe('getCsv', () => {
 
         const data = [
             {
-                test: 'test value!',
-                broken: 'broken value!',
+                first: 'first value 1!',
+                second: 'second value 1!',
+                hidden: 'hidden value 1!',
             },
             {
-                test: 'test value 2!',
-                broken: 'broken value 2!',
+                first: 'first value 2!',
+                second: 'second value 2!',
+                hidden: 'hidden value 2!',
+            },
+            {
+                first: 'first value 3!',
+                second: 'second value 3!',
+                hidden: 'hidden value 3!',
             },
         ] as any;
 
         const output = getCsv(data, columns);
 
-        expect(output).toEqual('test column\ntest value!\ntest value 2!\n');
+        expect(output).toEqual(
+            'first column,second column\nfirst value 1!,second value 1!\nfirst value 2!,second value 2!\nfirst value 3!,second value 3!\n',
+        );
     });
 });


### PR DESCRIPTION
I'm 99% sure this is the fix for this, but essentially if the last column in the table is not visible, we end up with some code like this:
```js
['t'].reduce(() => {return}, '') + '\n'
```
Which evaluates to
```
"undefined
"
```
If you run it in your browser.

If we return '', it just becomes '', but if we return the previous then we are all set. Please take a look at my unit test and replace the `return prev` with `return` to see what I mean