### PR TITLE
Feature: computed column

### DIFF
--- a/src/Models/ColumnModel.ts
+++ b/src/Models/ColumnModel.ts
@@ -3,10 +3,10 @@ import { AggregateFunctions, ColumnDataType, ColumnSortDirection, CompareOperato
 export interface ColumnModel {
     aggregate: AggregateFunctions;
     dataType: ColumnDataType;
-    dateOriginFormat: string; // YYYY-MM-DD (default)
-    dateDisplayFormat: string; // YYYY-MM-DD (default)
-    dateTimeOriginFormat: string; // YYYY-MM-DDTHH:mm:ss (default)
-    dateTimeDisplayFormat: string; // YYYY-MM-DDTHH:mm:ss (default)
+    dateOriginFormat?: string; // YYYY-MM-DD (default)
+    dateDisplayFormat?: string; // YYYY-MM-DD (default)
+    dateTimeOriginFormat?: string; // YYYY-MM-DDTHH:mm:ss (default)
+    dateTimeDisplayFormat?: string; // YYYY-MM-DDTHH:mm:ss (default)
     filterArgument: any[];
     filterOperator: CompareOperators;
     filterText: string;
@@ -14,6 +14,8 @@ export interface ColumnModel {
     exportable: boolean;
     isKey: boolean;
     label: string;
+    isComputed: boolean;
+    getComputedCsvValue?: (column: ColumnModel, row: any, isHeader: boolean) => string;
     name: string;
     searchable: boolean;
     sortDirection: ColumnSortDirection;

--- a/src/Models/ColumnModel.ts
+++ b/src/Models/ColumnModel.ts
@@ -15,7 +15,7 @@ export interface ColumnModel {
     isKey: boolean;
     label: string;
     isComputed: boolean;
-    getComputedCsvValue?: (column: ColumnModel, row: any, isHeader: boolean) => string;
+    getComputedStringValue?: (column: ColumnModel, row: any, isHeader: boolean) => string;
     name: string;
     searchable: boolean;
     sortDirection: ColumnSortDirection;

--- a/src/Models/GridRequest.ts
+++ b/src/Models/GridRequest.ts
@@ -13,7 +13,7 @@ export class GridRequest {
     public timezoneOffset: number;
 
     constructor(columns: ColumnModel[], itemsPerPage: number, page: number, searchText = '') {
-        this.columns = columns;
+        this.columns = columns.filter((c) => !c.isComputed);
         this.searchText = searchText;
         this.skip = itemsPerPage === -1 ? 0 : page * itemsPerPage;
         this.take = itemsPerPage;

--- a/src/Models/columnUtils.ts
+++ b/src/Models/columnUtils.ts
@@ -110,7 +110,7 @@ export const createColumn = (name: string, options?: Partial<ColumnModel>): Colu
         dateOriginFormat: temp.dateOriginFormat || defaultOriginDateFormat,
         dateTimeDisplayFormat: temp.dateTimeDisplayFormat || defaultDisplayDateTimeFormat,
         dateTimeOriginFormat: temp.dateTimeOriginFormat || defaultOriginDateTimeFormat,
-        getComputedCsvValue: temp.getComputedCsvValue || defaultComputedCsvValueGetter,
+        getComputedStringValue: temp.getComputedStringValue || defaultComputedCsvValueGetter,
         isKey: !!temp.isKey,
         isComputed: temp.isComputed === undefined ? false : temp.isComputed,
         label: temp.label || (name || '').replace(/([a-z])([A-Z])/g, '$1 $2'),

--- a/src/Models/columnUtils.ts
+++ b/src/Models/columnUtils.ts
@@ -97,9 +97,12 @@ export const sortColumnArray = (columnName: string, columns: ColumnModel[], mult
 export const columnHasFilter = (column: ColumnModel): boolean =>
     (!!column.filterText || !!column.filterArgument) && column.filterOperator !== CompareOperators.None;
 
+const defaultComputedCsvValueGetter = (column: ColumnModel, row: any, isHeader = false) => '';
+
 export const createColumn = (name: string, options?: Partial<ColumnModel>): ColumnModel => {
     const temp = options || {};
     const sortDirection = (temp.sortable && temp.sortDirection) || ColumnSortDirection.None;
+
     return {
         aggregate: temp.aggregate || AggregateFunctions.None,
         dataType: temp.dataType || ColumnDataType.String,
@@ -107,7 +110,9 @@ export const createColumn = (name: string, options?: Partial<ColumnModel>): Colu
         dateOriginFormat: temp.dateOriginFormat || defaultOriginDateFormat,
         dateTimeDisplayFormat: temp.dateTimeDisplayFormat || defaultDisplayDateTimeFormat,
         dateTimeOriginFormat: temp.dateTimeOriginFormat || defaultOriginDateTimeFormat,
+        getComputedCsvValue: temp.getComputedCsvValue || defaultComputedCsvValueGetter,
         isKey: !!temp.isKey,
+        isComputed: temp.isComputed === undefined ? false : temp.isComputed,
         label: temp.label || (name || '').replace(/([a-z])([A-Z])/g, '$1 $2'),
         name: name,
         searchable: !!temp.searchable,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,12 +40,12 @@ const objToArray = (row: any): any[] => (row instanceof Object ? Object.keys(row
 const processRow = (row: any, columns: ColumnModel[], isHeader: boolean): string => {
     const finalVal = objToArray(row).reduce((prev: string, value: [], i: number) => {
         const column = columns[i];
-        if (!column.visible || !column.exportable || (column.isComputed && !column.getComputedCsvValue)) {
+        if (!column.visible || !column.exportable || (column.isComputed && !column.getComputedStringValue)) {
             return prev;
         }
 
         let result = column.isComputed
-            ? column.getComputedCsvValue(column, row, isHeader)
+            ? column.getComputedStringValue(column, row, isHeader)
             : getCellValue(columns[i], value, isHeader).replace(/"/g, '""');
 
         if (result.search(/("|,|\n)/g) >= 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,11 +39,14 @@ const objToArray = (row: any): any[] => (row instanceof Object ? Object.keys(row
 
 const processRow = (row: any, columns: ColumnModel[], isHeader: boolean): string => {
     const finalVal = objToArray(row).reduce((prev: string, value: [], i: number) => {
-        if (!columns[i].visible || !columns[i].exportable) {
+        const column = columns[i];
+        if (!column.visible || !column.exportable || (column.isComputed && !column.getComputedCsvValue)) {
             return prev;
         }
 
-        let result = getCellValue(columns[i], value, isHeader).replace(/"/g, '""');
+        let result = column.isComputed
+            ? column.getComputedCsvValue(column, row, isHeader)
+            : getCellValue(columns[i], value, isHeader).replace(/"/g, '""');
 
         if (result.search(/("|,|\n)/g) >= 0) {
             result = `"${result}"`;

--- a/test/GridRequest.spec.ts
+++ b/test/GridRequest.spec.ts
@@ -2,7 +2,7 @@ import { GridRequest } from '../src/Models/GridRequest';
 
 describe('New GridRequest instance', () => {
     it('should have default values', () => {
-        const actual = new GridRequest(null, 1, 1);
+        const actual = new GridRequest([], 1, 1);
 
         expect(actual.skip).toBe(1);
         expect(actual.take).toBe(1);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -100,7 +100,6 @@ describe('getCsv', () => {
         expect(output).toContain('1,09 29 - 2020,09 29 - 2020,09 30 - 2020');
     });
 
-
     it('should export only exportable columns', () => {
         const columns = [
             createColumn('first', {
@@ -192,6 +191,61 @@ describe('getCsv', () => {
         const output = getCsv(data, columns);
 
         expect(output).toContain('first column,second column');
+    });
+
+    it('should export valid computed columns', () => {
+        const columns = [
+            createColumn('first', {
+                label: 'first column',
+                visible: true,
+                dataType: ColumnDataType.Numeric,
+            }),
+            createColumn('second', {
+                label: 'second column',
+                visible: true,
+                dataType: ColumnDataType.String,
+            }),
+            createColumn('computed', {
+                label: 'computed column',
+                visible: true,
+                dataType: ColumnDataType.String,
+                isComputed: true,
+                getComputedCsvValue: (column, row, isHeader) => {
+                    if (isHeader) {
+                        return column.label;
+                    }
+
+                    return `${row.first} + ${row.second}`;
+                },
+            }),
+            createColumn('hidden', {
+                label: 'hidden column',
+                visible: false,
+                dataType: ColumnDataType.String,
+            }),
+        ];
+
+        const data = [
+            {
+                first: 'first value 1!',
+                second: 'second value 1!',
+                hidden: 'hidden value 1!',
+            },
+            {
+                first: 'first value 2!',
+                second: 'second value 2!',
+                hidden: 'hidden value 2!',
+            },
+            {
+                first: 'first value 3!',
+                second: 'second value 3!',
+                hidden: 'hidden value 3!',
+            },
+        ] as any;
+
+        const output = getCsv(data, columns);
+
+        expect(output).toContain('first column,second column,computed column');
     });
 });
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -200,11 +200,6 @@ describe('getCsv', () => {
                 visible: true,
                 dataType: ColumnDataType.Numeric,
             }),
-            createColumn('second', {
-                label: 'second column',
-                visible: true,
-                dataType: ColumnDataType.String,
-            }),
             createColumn('computed', {
                 label: 'computed column',
                 visible: true,
@@ -216,6 +211,24 @@ describe('getCsv', () => {
                     }
 
                     return `${row.first} + ${row.second}`;
+                },
+            }),
+            createColumn('second', {
+                label: 'second column',
+                visible: true,
+                dataType: ColumnDataType.String,
+            }),
+            createColumn('computed2', {
+                label: 'computed column2',
+                visible: true,
+                dataType: ColumnDataType.String,
+                isComputed: true,
+                getComputedStringValue: (column, row, isHeader) => {
+                    if (isHeader) {
+                        return column.label;
+                    }
+
+                    return `${row.first} + ${row.second} 2`;
                 },
             }),
             createColumn('hidden', {
@@ -244,8 +257,7 @@ describe('getCsv', () => {
         ] as any;
 
         const output = getCsv(data, columns);
-
-        expect(output).toContain('first column,second column,computed column');
+        expect(output).toContain('first column,computed column,second column,computed column2');
     });
 });
 
@@ -291,6 +303,74 @@ describe('getHTML', () => {
 
         expect(output).toEqual(
             '<table class="table table-bordered table-striped"><thead><tr><th>first column</th><th>second column</th></tr></thead><tbody><tr><td>first value 1!</td><td>second value 1!</td></tr><tr><td>first value 2!</td><td>second value 2!</td></tr><tr><td>first value 3!</td><td>second value 3!</td></tr></tbody></table>',
+        );
+    });
+    it('should export valid computed columns', () => {
+        const columns = [
+            createColumn('first', {
+                label: 'first column',
+                visible: true,
+                dataType: ColumnDataType.Numeric,
+            }),
+            createColumn('computed', {
+                label: 'computed column',
+                visible: true,
+                dataType: ColumnDataType.String,
+                isComputed: true,
+                getComputedStringValue: (column, row, isHeader) => {
+                    if (isHeader) {
+                        return column.label;
+                    }
+
+                    return `${row.first} + ${row.second}`;
+                },
+            }),
+            createColumn('second', {
+                label: 'second column',
+                visible: true,
+                dataType: ColumnDataType.String,
+            }),
+            createColumn('hidden', {
+                label: 'hidden column',
+                visible: false,
+                dataType: ColumnDataType.String,
+            }),
+            createColumn('computed2', {
+                label: 'computed column2',
+                visible: true,
+                dataType: ColumnDataType.String,
+                isComputed: true,
+                getComputedStringValue: (column, row, isHeader) => {
+                    if (isHeader) {
+                        return column.label;
+                    }
+
+                    return `${row.first} + ${row.second} 2`;
+                },
+            }),
+        ];
+
+        const data = [
+            {
+                first: 'first value 1!',
+                second: 'second value 1!',
+                hidden: 'hidden value 1!',
+            },
+            {
+                first: 'first value 2!',
+                second: 'second value 2!',
+                hidden: 'hidden value 2!',
+            },
+            {
+                first: 'first value 3!',
+                second: 'second value 3!',
+                hidden: 'hidden value 3!',
+            },
+        ] as any;
+
+        const output = getHtml(data, columns);
+        expect(output).toBe(
+            '<table class="table table-bordered table-striped"><thead><tr><th>first column</th><th>computed column</th><th>second column</th><th>computed column2</th></tr></thead><tbody><tr><td>first value 1!</td><td>first value 1! + second value 1!</td><td>second value 1!</td><td>first value 1! + second value 1! 2</td></tr><tr><td>first value 2!</td><td>first value 2! + second value 2!</td><td>second value 2!</td><td>first value 2! + second value 2! 2</td></tr><tr><td>first value 3!</td><td>first value 3! + second value 3!</td><td>second value 3!</td><td>first value 3! + second value 3! 2</td></tr></tbody></table>',
         );
     });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -210,7 +210,7 @@ describe('getCsv', () => {
                 visible: true,
                 dataType: ColumnDataType.String,
                 isComputed: true,
-                getComputedCsvValue: (column, row, isHeader) => {
+                getComputedStringValue: (column, row, isHeader) => {
                     if (isHeader) {
                         return column.label;
                     }


### PR DESCRIPTION
There's the need to have computed columns. For example, for a grid with the following columns:
number 1 | number 2

It would be very useful to have the ability to add a third column, sum for example, where we can compute a value. This feature should also consider export functionality, which might export or not a computed column.

This proposal is introducing two props on column model:

```ts
isComputed: boolean; // This is just the flag
getComputedCsvValue?: (column: ColumnModel, row: any, isHeader: boolean) => string; // This is the function that will produce the value when exporting the computed column
```

An example would look like this:

```ts
createColumn('computed', {
    label: 'computed column',
    visible: true,
    dataType: ColumnDataType.String,
    isComputed: true,
    getComputedCsvValue: (column, row, isHeader) => {
        if (isHeader) {
            return column.label;
        }

        return `${row.first} + ${row.second}`;
    },
})
```